### PR TITLE
feat: skill games backend — settlement, replay validation, security h…

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -22,7 +22,7 @@ ERC4337_MODULE_ADDRESS=0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226
 SAFE_VERSION=1.4.1
 
 # ── Dice sweeper ──────────────────────────────────────────────────────────────
-# Relayer wallet set as the dice randomness operator.
+# Relayer wallet that calls requestRoundRandomness / drawRound.
 CELO_RELAYER_PK=
 
 # Celo JSON-RPC endpoint (defaults to public forno).
@@ -37,14 +37,11 @@ DICE_SWEEP_INTERVAL_SECONDS=60
 # Optional: override which tiers to scan (comma-separated, default all).
 # DICE_TIERS=10,20,30,250,500,1000
 
-# Number of unrevealed house commits to keep queued on-chain.
-# DICE_COMMIT_BUFFER=24
+# Buffer added on top of the Witnet fee estimate, in basis points (default 1000 = 10%).
+# DICE_FEE_BUFFER_BPS=1000
 
-# Maximum commits queued in a single sweep transaction.
-# DICE_COMMIT_BATCH_SIZE=24
-
-# Reanchor full legacy rounds that are still stuck waiting on Witnet.
-# DICE_REANCHOR_LEGACY_FULL_ROUNDS=true
+# Hard fallback fee in wei if Witnet fee estimation fails entirely.
+# WITNET_FEE_WEI=15000000000000000
 
 # How often to retry tracked unresolved rounds, in seconds (default 300 = 5 min).
 # DICE_UNRESOLVED_RETRY_INTERVAL_SECONDS=300

--- a/packages/backend/src/diceSweeper.ts
+++ b/packages/backend/src/diceSweeper.ts
@@ -1,9 +1,8 @@
 // src/diceSweeper.ts
 //
 // Periodically reconciles active AkibaDice rounds so that:
-//   - commit secrets are kept queued on-chain before new rounds open
-//   - full rounds lock a future block for randomness
-//   - rounds in "Ready" state are revealed and drawn immediately
+//   - randomness is requested as soon as a round has any players and no randomBlock
+//   - rounds in "Ready" state are drawn immediately
 //
 // The sweeper persists unresolved rounds in Supabase so Railway restarts do not
 // lose tracked backlog. A small tier watch-state table is also used so the
@@ -22,7 +21,7 @@ import { supabase } from "./supabaseClient";
 const DICE_ADDRESS =
   process.env.DICE_ADDRESS ?? "0xf77e7395Aa5c89BcC8d6e23F67a9c7914AB9702a";
 
-const ZERO_BYTES32 = `0x${"0".repeat(64)}`;
+const WITNET_RNG_ADDRESS = "0xC0FFEE98AD1434aCbDB894BbB752e138c1006fAB";
 
 const CELO_RPC_URL = process.env.CELO_RPC_URL ?? "https://forno.celo.org";
 
@@ -37,19 +36,12 @@ const ACTIVE_TIERS: number[] = process.env.DICE_TIERS
   ? process.env.DICE_TIERS.split(",").map((t) => Number(t.trim()))
   : DEFAULT_TIERS;
 
-const MIN_ROUND_ID = BigInt(process.env.DICE_MIN_ROUND_ID ?? "23750");
+const FEE_BUFFER_BPS = Number(process.env.DICE_FEE_BUFFER_BPS ?? "0"); // no buffer — Witnet rejects excess
 const UNRESOLVED_RETRY_INTERVAL_SECONDS = Number(
   process.env.DICE_UNRESOLVED_RETRY_INTERVAL_SECONDS ?? "300"
 );
-const COMMIT_BUFFER = Number(process.env.DICE_COMMIT_BUFFER ?? "24");
-const COMMIT_BATCH_SIZE = Number(
-  process.env.DICE_COMMIT_BATCH_SIZE ?? String(COMMIT_BUFFER)
-);
-const REANCHOR_LEGACY_FULL_ROUNDS =
-  process.env.DICE_REANCHOR_LEGACY_FULL_ROUNDS !== "false";
 const UNRESOLVED_TABLE = "dice_unresolved_rounds";
 const TIER_STATE_TABLE = "dice_tier_watch_state";
-const COMMIT_TABLE = "dice_house_commits";
 
 // ── ABIs ──────────────────────────────────────────────────────────────────────
 
@@ -59,16 +51,10 @@ const DICE_ABI = [
   "function getRoundState(uint256 roundId) external view returns (uint8)",
   "function requestRoundRandomness(uint256 roundId) external payable",
   "function drawRound(uint256 roundId) external",
-  "function revealAndDraw(uint256 roundId, bytes32 secret) external",
-  "function cancelExpiredReveal(uint256 roundId) external",
-  "function reanchorCommitReveal(uint256 roundId) external",
-  "function nextHouseCommitNonce() external view returns (uint256)",
-  "function nextHouseCommitToUse() external view returns (uint256)",
-  "function queueHouseCommits(bytes32[] commits) external",
-  "function roundHouseCommit(uint256 roundId) external view returns (bytes32)",
-  "function roundHouseCommitNonce(uint256 roundId) external view returns (uint256)",
-  "function roundTargetBlock(uint256 roundId) external view returns (uint256)",
-  "function roundRevealDeadlineBlock(uint256 roundId) external view returns (uint256)",
+];
+
+const WITNET_ABI = [
+  "function estimateRandomizeFee(uint256 evmGasPrice) external view returns (uint256)",
 ];
 
 // ── Round state enum ──────────────────────────────────────────────────────────
@@ -86,198 +72,6 @@ function stateName(s: number): string {
   return (
     Object.entries(RoundState).find(([, v]) => v === s)?.[0] ?? `Unknown(${s})`
   );
-}
-
-function isRoundInScope(roundId: bigint | string): boolean {
-  return BigInt(roundId) >= MIN_ROUND_ID;
-}
-
-function normalizePrivateKey(pk: string): string {
-  return pk.startsWith("0x") ? pk : `0x${pk}`;
-}
-
-function makeHouseCommit(
-  secret: string,
-  nonce: bigint,
-  chainId: bigint
-): string {
-  return ethers.solidityPackedKeccak256(
-    ["bytes32", "address", "uint256", "uint256"],
-    [secret, DICE_ADDRESS, chainId, nonce]
-  );
-}
-
-interface DiceHouseCommitRow {
-  nonce: string;
-  chain_id: string;
-  dice_address: string;
-  commit: string;
-  secret: string;
-  status: "prepared" | "queued" | "assigned" | "revealed" | "expired" | "failed";
-  round_id: string | null;
-}
-
-async function ensureCommitBuffer(
-  dice: ethers.Contract,
-  provider: ethers.JsonRpcProvider
-): Promise<void> {
-  if (COMMIT_BUFFER <= 0) return;
-
-  const [nextNonceRaw, nextToUseRaw, network] = await Promise.all([
-    dice.nextHouseCommitNonce(),
-    dice.nextHouseCommitToUse(),
-    provider.getNetwork(),
-  ]);
-
-  const nextNonce = BigInt(nextNonceRaw);
-  const nextToUse = BigInt(nextToUseRaw);
-  const pending = nextNonce > nextToUse ? nextNonce - nextToUse : 0n;
-  const needed = BigInt(COMMIT_BUFFER) - pending;
-
-  if (needed <= 0n) {
-    console.log(
-      `[diceSweeper] Commit buffer ok pending=${pending.toString()} ` +
-        `next=${nextNonce.toString()} use=${nextToUse.toString()}`
-    );
-    return;
-  }
-
-  const batchSize = Math.min(Number(needed), Math.max(1, COMMIT_BATCH_SIZE));
-  const chainId = BigInt(network.chainId);
-  const rows: Array<Omit<DiceHouseCommitRow, "round_id"> & { round_id: null }> = [];
-  const commits: string[] = [];
-
-  for (let i = 0; i < batchSize; i++) {
-    const nonce = nextNonce + BigInt(i);
-    const secret = ethers.hexlify(ethers.randomBytes(32));
-    const commit = makeHouseCommit(secret, nonce, chainId);
-
-    rows.push({
-      nonce: nonce.toString(),
-      chain_id: chainId.toString(),
-      dice_address: DICE_ADDRESS.toLowerCase(),
-      commit,
-      secret,
-      status: "prepared",
-      round_id: null,
-    });
-    commits.push(commit);
-  }
-
-  const { error: insertError } = await supabase
-    .from(COMMIT_TABLE)
-    .upsert(rows, { onConflict: "nonce" });
-
-  if (insertError) {
-    throw new Error(`failed saving dice commits: ${insertError.message}`);
-  }
-
-  const tx = await dice.queueHouseCommits(commits);
-  const receipt = await tx.wait();
-  const queuedAt = new Date().toISOString();
-
-  const { error: updateError } = await supabase
-    .from(COMMIT_TABLE)
-    .update({
-      status: "queued",
-      queue_tx_hash: receipt?.hash ?? tx.hash,
-      queued_at: queuedAt,
-      last_error: null,
-    })
-    .in(
-      "nonce",
-      rows.map((row) => row.nonce)
-    );
-
-  if (updateError) {
-    console.warn(
-      `[diceSweeper] queued commits on-chain but failed DB update: ${updateError.message}`
-    );
-  }
-
-  console.log(
-    `[diceSweeper] Queued ${commits.length} house commits ` +
-      `nonce=${rows[0].nonce}..${rows[rows.length - 1].nonce} ` +
-      `tx=${receipt?.hash ?? tx.hash}`
-  );
-}
-
-async function getCommitSecret(
-  roundId: bigint,
-  nonce: bigint
-): Promise<string> {
-  const { data, error } = await supabase
-    .from(COMMIT_TABLE)
-    .select("nonce, secret, status, round_id")
-    .eq("nonce", nonce.toString())
-    .maybeSingle();
-
-  if (error) {
-    throw new Error(`failed loading commit nonce=${nonce.toString()}: ${error.message}`);
-  }
-
-  const row = data as Pick<DiceHouseCommitRow, "nonce" | "secret" | "status" | "round_id"> | null;
-  if (!row?.secret) {
-    throw new Error(`missing reveal secret for round=${roundId.toString()} nonce=${nonce.toString()}`);
-  }
-
-  await supabase
-    .from(COMMIT_TABLE)
-    .update({
-      status: "assigned",
-      round_id: roundId.toString(),
-      assigned_at: new Date().toISOString(),
-      last_error: null,
-    })
-    .eq("nonce", nonce.toString())
-    .neq("status", "revealed");
-
-  return row.secret;
-}
-
-async function markCommitRevealed(
-  nonce: bigint,
-  roundId: bigint,
-  txHash: string
-): Promise<void> {
-  const { error } = await supabase
-    .from(COMMIT_TABLE)
-    .update({
-      status: "revealed",
-      round_id: roundId.toString(),
-      reveal_tx_hash: txHash,
-      revealed_at: new Date().toISOString(),
-      last_error: null,
-    })
-    .eq("nonce", nonce.toString());
-
-  if (error) {
-    console.warn(
-      `[diceSweeper] failed marking commit nonce=${nonce.toString()} revealed: ${error.message}`
-    );
-  }
-}
-
-async function markCommitExpired(
-  nonce: bigint,
-  roundId: bigint,
-  txHash: string
-): Promise<void> {
-  const { error } = await supabase
-    .from(COMMIT_TABLE)
-    .update({
-      status: "expired",
-      round_id: roundId.toString(),
-      reveal_tx_hash: txHash,
-      expired_at: new Date().toISOString(),
-    })
-    .eq("nonce", nonce.toString());
-
-  if (error) {
-    console.warn(
-      `[diceSweeper] failed marking commit nonce=${nonce.toString()} expired: ${error.message}`
-    );
-  }
 }
 
 // ── Persisted unresolved-round registry ───────────────────────────────────────
@@ -425,9 +219,7 @@ async function loadActiveUnresolvedRounds(): Promise<UnresolvedRoundEntry[]> {
     return [];
   }
 
-  return ((data ?? []) as UnresolvedRoundRow[])
-    .map(rowToEntry)
-    .filter((entry) => isRoundInScope(entry.roundId));
+  return ((data ?? []) as UnresolvedRoundRow[]).map(rowToEntry);
 }
 
 async function incrementRetry(
@@ -494,12 +286,7 @@ type SweepAction =
   | "skip-no-players"
   | "skip-already-resolved"
   | "skip-randomness-pending"
-  | "skip-before-min-round"
   | "requested-randomness"
-  | "reanchored-commit"
-  | "revealed-drew"
-  | "legacy-drew"
-  | "cancelled-expired-reveal"
   | "drew"
   | "error";
 
@@ -523,22 +310,16 @@ export async function runDiceSweep(): Promise<RoundResult[]> {
   }
 
   const provider = new ethers.JsonRpcProvider(CELO_RPC_URL);
-  const wallet = new ethers.Wallet(normalizePrivateKey(RELAYER_PK), provider);
+  const wallet = new ethers.Wallet(RELAYER_PK, provider);
   const dice = new ethers.Contract(DICE_ADDRESS, DICE_ABI, wallet);
+  const rng = new ethers.Contract(WITNET_RNG_ADDRESS, WITNET_ABI, provider);
   const tierWatchState = await loadTierWatchState();
 
-  try {
-    await ensureCommitBuffer(dice, provider);
-  } catch (err: any) {
-    console.warn(
-      `[diceSweeper] failed ensuring commit buffer: ${err?.shortMessage ?? err?.message ?? err}`
-    );
-  }
-
+  const witnetFee = await estimateFee(provider, rng);
   const results: RoundResult[] = [];
 
   for (const tier of ACTIVE_TIERS) {
-    const result = await processTier(tier, dice, provider, tierWatchState);
+    const result = await processTier(tier, dice, witnetFee, tierWatchState);
     results.push(result);
 
     console.log(
@@ -555,12 +336,35 @@ export async function runDiceSweep(): Promise<RoundResult[]> {
   return results;
 }
 
+// ── Fee estimation ────────────────────────────────────────────────────────────
+
+async function estimateFee(
+  provider: ethers.JsonRpcProvider,
+  rng: ethers.Contract
+): Promise<bigint> {
+  try {
+    const feeData = await provider.getFeeData();
+    const gasPrice = feeData.gasPrice ?? ethers.parseUnits("5", "gwei");
+    const raw: bigint = await rng.estimateRandomizeFee(gasPrice);
+    return (raw * BigInt(10_000 + FEE_BUFFER_BPS)) / 10_000n;
+  } catch (err: any) {
+    const fallback = process.env.WITNET_FEE_WEI
+      ? BigInt(process.env.WITNET_FEE_WEI)
+      : ethers.parseEther("0.015");
+    console.warn(
+      `[diceSweeper] estimateRandomizeFee failed (${err?.message}), ` +
+        `using fallback ${ethers.formatEther(fallback)} CELO`
+    );
+    return fallback;
+  }
+}
+
 // ── Tier + unresolved processing ──────────────────────────────────────────────
 
 async function processTier(
   tier: number,
   dice: ethers.Contract,
-  provider: ethers.JsonRpcProvider,
+  witnetFee: bigint,
   tierWatchState: Record<string, string>
 ): Promise<RoundResult> {
   const activeRoundId = (await dice.getActiveRoundId(BigInt(tier))) as bigint;
@@ -578,22 +382,7 @@ async function processTier(
   const activeRoundIdStr = activeRoundId.toString();
   const previousActiveRoundId = tierWatchState[String(tier)];
 
-  if (!isRoundInScope(activeRoundId)) {
-    return {
-      roundId: activeRoundIdStr,
-      tier,
-      filledSlots: 0,
-      randomBlock: "0",
-      state: `BeforeMinRound(${MIN_ROUND_ID.toString()})`,
-      action: "skip-before-min-round",
-    };
-  }
-
-  if (
-    previousActiveRoundId &&
-    previousActiveRoundId !== activeRoundIdStr &&
-    isRoundInScope(previousActiveRoundId)
-  ) {
+  if (previousActiveRoundId && previousActiveRoundId !== activeRoundIdStr) {
     try {
       const [, prevFilledSlots, prevWinnerSelected, , prevRandomBlock] =
         (await dice.getRoundInfo(BigInt(previousActiveRoundId))) as [
@@ -638,14 +427,14 @@ async function processTier(
   await setTierWatchState(tier, activeRoundIdStr);
   await markResolvedRound(activeRoundIdStr);
 
-  return processRound(activeRoundId, tier, dice, provider);
+  return processRound(activeRoundId, tier, dice, witnetFee);
 }
 
 async function processRound(
   roundId: bigint,
   tier: number,
   dice: ethers.Contract,
-  provider: ethers.JsonRpcProvider
+  witnetFee: bigint
 ): Promise<RoundResult> {
   const base: Omit<RoundResult, "action"> = {
     roundId: roundId.toString(),
@@ -654,14 +443,6 @@ async function processRound(
     randomBlock: "0",
     state: "Unknown",
   };
-
-  if (!isRoundInScope(roundId)) {
-    return {
-      ...base,
-      state: `BeforeMinRound(${MIN_ROUND_ID.toString()})`,
-      action: "skip-before-min-round",
-    };
-  }
 
   try {
     const [, filledSlots, winnerSelected, , randomBlock] =
@@ -692,50 +473,12 @@ async function processRound(
     ) as RoundStateValue;
     base.state = stateName(stateNum);
 
-    const [houseCommit, targetBlockRaw, deadlineBlockRaw] = (await Promise.all([
-      dice.roundHouseCommit(roundId),
-      dice.roundTargetBlock(roundId),
-      dice.roundRevealDeadlineBlock(roundId),
-    ])) as [string, bigint, bigint];
-    const hasCommit = houseCommit !== ZERO_BYTES32;
-    const targetBlock = BigInt(targetBlockRaw);
-    const deadlineBlock = BigInt(deadlineBlockRaw);
-
-    if (base.filledSlots < 6) {
-      return { ...base, action: "skip-randomness-pending" };
-    }
-
-    if (hasCommit && targetBlock > 0n) {
-      const currentBlock = BigInt(await provider.getBlockNumber());
-      if (currentBlock > deadlineBlock || currentBlock > targetBlock + 255n) {
-        const nonce = BigInt(await dice.roundHouseCommitNonce(roundId));
-        console.warn(
-          `[diceSweeper] Reveal expired — round=${roundId} target=${targetBlock} ` +
-            `deadline=${deadlineBlock} current=${currentBlock}; cancelling/refunding`
-        );
-        const tx = await dice.cancelExpiredReveal(roundId);
-        const receipt = await tx.wait();
-        const txHash = receipt?.hash ?? tx.hash;
-        await markCommitExpired(nonce, roundId, txHash);
-        return {
-          ...base,
-          action: "cancelled-expired-reveal",
-          txHash,
-        };
-      }
-    }
-
-    if ((randomBlock === 0n || (hasCommit && targetBlock === 0n)) && stateNum !== RoundState.Resolved) {
+    if (randomBlock === 0n && stateNum !== RoundState.Resolved) {
       try {
-        console.log(
-          `[diceSweeper] Locking commit randomness — round=${roundId} tier=${tier} ` +
-          `slots=${base.filledSlots}`
-        );
-        const tx = await dice.requestRoundRandomness(roundId);
+        const tx = await dice.requestRoundRandomness(roundId, {
+          value: witnetFee,
+        });
         const receipt = await tx.wait();
-        console.log(
-          `[diceSweeper] Commit randomness locked — round=${roundId} tx=${receipt?.hash ?? tx.hash}`
-        );
         return {
           ...base,
           action: "requested-randomness",
@@ -747,58 +490,19 @@ async function processRound(
           msg.includes("already requested") ||
           msg.includes("randomness requested")
         ) {
-          console.log(`[diceSweeper] Randomness already requested for round=${roundId}, skipping`);
           return { ...base, action: "skip-randomness-pending" };
         }
         throw err;
       }
     }
 
-    if (!hasCommit && randomBlock !== 0n && stateNum === RoundState.FullWaiting && REANCHOR_LEGACY_FULL_ROUNDS) {
-      console.log(
-        `[diceSweeper] Reanchoring legacy randomness — round=${roundId} tier=${tier} ` +
-          `oldRandomBlock=${base.randomBlock}`
-      );
-      const tx = await dice.reanchorCommitReveal(roundId);
-      const receipt = await tx.wait();
-      return {
-        ...base,
-        action: "reanchored-commit",
-        txHash: receipt?.hash ?? tx.hash,
-      };
-    }
-
     if (stateNum === RoundState.Ready) {
       try {
-        if (hasCommit) {
-          const nonce = BigInt(await dice.roundHouseCommitNonce(roundId));
-          const secret = await getCommitSecret(roundId, nonce);
-          console.log(
-            `[diceSweeper] Revealing round — round=${roundId} tier=${tier} ` +
-              `nonce=${nonce.toString()} target=${targetBlock.toString()}`
-          );
-          const tx = await dice.revealAndDraw(roundId, secret);
-          const receipt = await tx.wait();
-          const txHash = receipt?.hash ?? tx.hash;
-          await markCommitRevealed(nonce, roundId, txHash);
-          console.log(`[diceSweeper] Round revealed/drawn — round=${roundId} tx=${txHash}`);
-          return {
-            ...base,
-            action: "revealed-drew",
-            txHash,
-          };
-        }
-
-        console.log(
-          `[diceSweeper] Drawing legacy round — round=${roundId} tier=${tier} ` +
-          `randomBlock=${base.randomBlock}`
-        );
         const tx = await dice.drawRound(roundId);
         const receipt = await tx.wait();
-        console.log(`[diceSweeper] Round drawn — round=${roundId} tx=${receipt?.hash ?? tx.hash}`);
         return {
           ...base,
-          action: "legacy-drew",
+          action: "drew",
           txHash: receipt?.hash ?? tx.hash,
         };
       } catch (err: any) {
@@ -807,7 +511,6 @@ async function processRound(
           msg.includes("already resolved") ||
           msg.includes("randomness pending")
         ) {
-          console.log(`[diceSweeper] round=${roundId} already resolved (push callback beat us)`);
           return { ...base, action: "skip-already-resolved" };
         }
         throw err;
@@ -836,16 +539,10 @@ export async function retryTrackedUnresolvedRounds(): Promise<UnresolvedRoundEnt
   }
 
   const provider = new ethers.JsonRpcProvider(CELO_RPC_URL);
-  const wallet = new ethers.Wallet(normalizePrivateKey(RELAYER_PK), provider);
+  const wallet = new ethers.Wallet(RELAYER_PK, provider);
   const dice = new ethers.Contract(DICE_ADDRESS, DICE_ABI, wallet);
-
-  try {
-    await ensureCommitBuffer(dice, provider);
-  } catch (err: any) {
-    console.warn(
-      `[diceSweeper] failed ensuring commit buffer during retry: ${err?.shortMessage ?? err?.message ?? err}`
-    );
-  }
+  const rng = new ethers.Contract(WITNET_RNG_ADDRESS, WITNET_ABI, provider);
+  const witnetFee = await estimateFee(provider, rng);
 
   for (const entry of unresolvedRounds) {
     try {
@@ -853,14 +550,11 @@ export async function retryTrackedUnresolvedRounds(): Promise<UnresolvedRoundEnt
         BigInt(entry.roundId),
         entry.tier,
         dice,
-        provider
+        witnetFee
       );
 
       if (
         result.action === "drew" ||
-        result.action === "legacy-drew" ||
-        result.action === "revealed-drew" ||
-        result.action === "cancelled-expired-reveal" ||
         (result.action === "skip-already-resolved" && result.state === stateName(RoundState.Resolved))
       ) {
         await incrementRetry(entry.roundId, null, result.action);
@@ -884,14 +578,7 @@ export async function retryTrackedUnresolvedRounds(): Promise<UnresolvedRoundEnt
         updated.lastAction
       );
 
-      if (
-        updated.lastAction === "requested-randomness" ||
-        updated.lastAction === "reanchored-commit" ||
-        updated.lastAction === "revealed-drew" ||
-        updated.lastAction === "legacy-drew" ||
-        updated.lastAction === "cancelled-expired-reveal" ||
-        updated.lastAction === "drew"
-      ) {
+      if (updated.lastAction === "requested-randomness" || updated.lastAction === "drew") {
         console.log(
           `[diceSweeper] retried unresolved round=${entry.roundId} action=${updated.lastAction}`
         );
@@ -929,8 +616,7 @@ export function startDiceSweeper(): void {
 
   console.log(
     `[diceSweeper] Starting — tiers=[${ACTIVE_TIERS.join(",")}] ` +
-      `interval=${SWEEP_INTERVAL_SECONDS}s address=${DICE_ADDRESS} ` +
-      `minRoundId=${MIN_ROUND_ID.toString()} unresolvedTable=${UNRESOLVED_TABLE}`
+      `interval=${SWEEP_INTERVAL_SECONDS}s address=${DICE_ADDRESS} unresolvedTable=${UNRESOLVED_TABLE}`
   );
 
   runDiceSweep().catch((err) =>

--- a/packages/backend/src/games/config.ts
+++ b/packages/backend/src/games/config.ts
@@ -1,0 +1,34 @@
+import type { GameType, RewardThreshold } from "./types";
+
+export const SHARED_DAILY_PLAY_CAP = 30;
+
+export const GAME_TYPE_ID: Record<GameType, number> = {
+  rule_tap: 1,
+  memory_flip: 2,
+};
+
+export const GAME_CONFIGS: Record<GameType, {
+  chainGameType: number;
+  thresholds: RewardThreshold[];
+}> = {
+  rule_tap: {
+    chainGameType: 1,
+    thresholds: [
+      { label: "Warm up", minScore: 10, miles: 6, stable: 0 },
+      { label: "Sharp", minScore: 14, miles: 9, stable: 0 },
+      { label: "Elite", minScore: 18, miles: 12, stable: 0 },
+    ],
+  },
+  memory_flip: {
+    chainGameType: 2,
+    thresholds: [
+      { label: "Memory", minScore: 200, miles: 6, stable: 0 },
+      { label: "Sharp", minScore: 500, miles: 9, stable: 0 },
+      { label: "Recall Pro", minScore: 750, miles: 12, stable: 0 },
+    ],
+  },
+};
+
+export function isGameType(value: unknown): value is GameType {
+  return value === "rule_tap" || value === "memory_flip";
+}

--- a/packages/backend/src/games/contracts.ts
+++ b/packages/backend/src/games/contracts.ts
@@ -1,0 +1,13 @@
+export const SETTLEMENT_TYPEHASH_PREIMAGE =
+  "AkibaSkillGameSettlement(uint256 sessionId,address player,uint8 gameType,uint256 score,uint256 rewardMiles,uint256 rewardStable,uint256 expiry,address verifyingContract,uint256 chainId)";
+
+export const START_INTENT_TYPEHASH_PREIMAGE =
+  "AkibaStartIntent(address player,uint8 gameType,bytes32 seedCommitment,uint256 nonce,uint256 expiry,address verifyingContract,uint256 chainId)";
+
+export const akibaSkillGamesAbi = [
+  "function playerStatus(address player,uint8 gameType) view returns (uint256 credits,uint256 playsToday,uint256 playsRemaining)",
+  "function startNonces(address player) view returns (uint256)",
+  "function startGameFor(address player,uint8 gameType,bytes32 seedCommitment,uint256 nonce,uint256 expiry,bytes playerSignature) returns (uint256)",
+  "function settleGame(uint256 sessionId,uint256 score,uint256 rewardMiles,uint256 rewardStable,uint256 expiry,bytes signature)",
+  "event GameStarted(uint256 indexed sessionId,address indexed player,uint8 indexed gameType,uint256 entryCost,bytes32 seedCommitment)",
+] as const;

--- a/packages/backend/src/games/replayValidation.ts
+++ b/packages/backend/src/games/replayValidation.ts
@@ -1,0 +1,229 @@
+import { concat, keccak256, toUtf8Bytes } from "ethers";
+import { rewardForScore, scoreMemoryFlip, scoreRuleTap } from "./score";
+import type {
+  GameResult,
+  GameType,
+  MemoryFlipReplay,
+  RuleTapReplay,
+} from "./types";
+
+type Rng = () => number;
+type RuleTapTileColor = "blue" | "green" | "red" | "gold";
+type RuleTapTileKind = "star" | "circle" | "square" | "diamond";
+type RuleTapRule = {
+  targets: Array<{ color: RuleTapTileColor; kind: RuleTapTileKind }>;
+};
+type RuleTapTile = {
+  index: number;
+  color: RuleTapTileColor;
+  kind: RuleTapTileKind;
+  activeFromMs: number;
+  activeToMs: number;
+};
+
+function hashSeed(input: string) {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function createRng(seed: string): Rng {
+  let state = hashSeed(seed) || 1;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function seedCommitment(seed: string, walletAddress: string, gameType: GameType): string {
+  return keccak256(concat([toUtf8Bytes(seed), toUtf8Bytes(walletAddress.toLowerCase()), toUtf8Bytes(gameType)]));
+}
+
+const colors = ["blue", "green", "red", "gold"] as const;
+const kinds = ["star", "circle", "square", "diamond"] as const;
+
+function generateRuleTapSession(seed: string) {
+  const rng = createRng(seed);
+  const target = {
+    color: colors[Math.floor(rng() * colors.length)],
+    kind: kinds[Math.floor(rng() * kinds.length)],
+  };
+  const avoid = {
+    color: colors[Math.floor(rng() * colors.length)],
+    kind: kinds[Math.floor(rng() * kinds.length)],
+  };
+  const rule: RuleTapRule = { targets: [target] };
+  const timeline: RuleTapTile[][] = [];
+  for (let tick = 0; tick < 40; tick++) {
+    const activeCount = 1 + Math.floor(rng() * 3);
+    const used = new Set<number>();
+    const tiles: RuleTapTile[] = [];
+    for (let i = 0; i < activeCount; i++) {
+      let index = Math.floor(rng() * 9);
+      while (used.has(index)) index = Math.floor(rng() * 9);
+      used.add(index);
+      const forceTarget = rng() > 0.56;
+      const forceAvoid = !forceTarget && rng() > 0.72;
+      const color = forceTarget ? target.color : forceAvoid ? avoid.color : colors[Math.floor(rng() * colors.length)];
+      const kind = forceTarget ? target.kind : forceAvoid ? avoid.kind : kinds[Math.floor(rng() * kinds.length)];
+      tiles.push({
+        index,
+        color,
+        kind,
+        activeFromMs: tick * 500,
+        activeToMs: tick * 500 + 850,
+      });
+    }
+    timeline.push(tiles);
+  }
+  return { rule, timeline };
+}
+
+function generateMemoryDeck(seed: string) {
+  const rng = createRng(seed);
+  const pairs = ["sun", "bolt", "leaf", "gem", "wave", "key", "moon", "spark"];
+  const deck = [...pairs, ...pairs].map((value, index) => ({ id: `${value}-${index}`, value }));
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}
+
+const TILE_WINDOW_TOLERANCE_MS = 120;
+
+function activeTileAt(seed: string, offsetMs: number, tileIndex: number) {
+  const { timeline } = generateRuleTapSession(seed);
+  return timeline
+    .flat()
+    .find(
+      (tile) =>
+        tile.index === tileIndex &&
+        offsetMs >= tile.activeFromMs &&
+        offsetMs <= tile.activeToMs + TILE_WINDOW_TOLERANCE_MS
+    );
+}
+
+function matchesRule(tile: RuleTapTile | undefined, rule: RuleTapRule) {
+  if (!tile) return false;
+  return rule.targets.some((target) => target.color === tile.color && target.kind === tile.kind);
+}
+
+export function validateRuleTapReplay(replay: RuleTapReplay): { result: GameResult; flags: string[] } {
+  const flags: string[] = [];
+  const { rule } = generateRuleTapSession(replay.seed);
+  let correct = 0;
+  let mistakes = 0;
+  let previousOffset = -1;
+  const intervals: number[] = [];
+
+  for (const action of replay.actions) {
+    if (action.offsetMs < 120) flags.push("reaction_time_below_120ms");
+    if (action.offsetMs < previousOffset) flags.push("non_monotonic_action_log");
+    if (previousOffset >= 0) intervals.push(action.offsetMs - previousOffset);
+    previousOffset = action.offsetMs;
+    if (action.tileIndex < 0 || action.tileIndex > 8) {
+      mistakes++;
+      flags.push("invalid_tile_index");
+      continue;
+    }
+    const tile = activeTileAt(replay.seed, action.offsetMs, action.tileIndex);
+    if (matchesRule(tile, rule)) correct++;
+    else mistakes++;
+  }
+
+  if (intervals.length >= 6 && new Set(intervals.slice(-8)).size <= 2) {
+    flags.push("repeated_exact_timing_pattern");
+  }
+
+  const score = scoreRuleTap(correct, mistakes);
+  const reward = rewardForScore("rule_tap", score);
+  return {
+    flags: [...new Set(flags)],
+    result: {
+      sessionId: replay.sessionId,
+      gameType: "rule_tap",
+      score,
+      mistakes,
+      completed: replay.durationMs >= 18_000,
+      elapsedMs: replay.durationMs,
+      rewardMiles: reward.rewardMiles,
+      rewardStable: reward.rewardStable,
+      reason: correct ? undefined : "No valid targets tapped",
+    },
+  };
+}
+
+export function validateMemoryFlipReplay(replay: MemoryFlipReplay): { result: GameResult; flags: string[] } {
+  const deck = generateMemoryDeck(replay.seed);
+  const flags: string[] = [];
+  const revealed = new Set<number>();
+  let selected: number[] = [];
+  let moves = 0;
+  let matches = 0;
+  let mistakes = 0;
+  let lockUntil = 0;
+  let previousOffset = -1;
+  const intervals: number[] = [];
+
+  for (const action of replay.actions) {
+    if (action.offsetMs < previousOffset) flags.push("non_monotonic_action_log");
+    if (previousOffset >= 0) intervals.push(action.offsetMs - previousOffset);
+    previousOffset = action.offsetMs;
+    if (action.offsetMs < lockUntil) {
+      flags.push("input_during_pair_evaluation_lock");
+      continue;
+    }
+    if (action.cardIndex < 0 || action.cardIndex >= deck.length || revealed.has(action.cardIndex)) {
+      flags.push("invalid_or_revealed_card_flip");
+      continue;
+    }
+    if (selected.includes(action.cardIndex)) {
+      flags.push("same_card_double_flip");
+      continue;
+    }
+    selected.push(action.cardIndex);
+    if (selected.length === 2) {
+      moves++;
+      const [a, b] = selected;
+      if (deck[a].value === deck[b].value) {
+        revealed.add(a);
+        revealed.add(b);
+        matches++;
+      } else {
+        mistakes++;
+        lockUntil = action.offsetMs + 520;
+      }
+      selected = [];
+    }
+  }
+
+  if (matches === 8 && replay.durationMs < 7_500) flags.push("impossible_completion_time");
+  if (intervals.length >= 8 && intervals.every((interval) => interval < 170)) flags.push("sustained_machine_speed_inputs");
+  if (intervals.length >= 10 && new Set(intervals.slice(-10)).size <= 2) flags.push("repeated_exact_timing_pattern");
+
+  const completed = matches === 8;
+  const score = scoreMemoryFlip({ completed, matches, moves, mistakes, elapsedMs: replay.durationMs, durationMs: 60_000 });
+  const reward = rewardForScore("memory_flip", score);
+  return {
+    flags: [...new Set(flags)],
+    result: {
+      sessionId: replay.sessionId,
+      gameType: "memory_flip",
+      score,
+      mistakes,
+      moves,
+      matches,
+      completed,
+      elapsedMs: replay.durationMs,
+      rewardMiles: reward.rewardMiles,
+      rewardStable: reward.rewardStable,
+    },
+  };
+}

--- a/packages/backend/src/games/routes.ts
+++ b/packages/backend/src/games/routes.ts
@@ -1,0 +1,425 @@
+import { Router } from "express";
+import {
+  AbiCoder,
+  Contract,
+  Interface,
+  JsonRpcProvider,
+  Wallet,
+  getBytes,
+  hashMessage,
+  id,
+  keccak256,
+  recoverAddress,
+} from "ethers";
+import { supabase } from "../supabaseClient";
+import { GAME_TYPE_ID, SHARED_DAILY_PLAY_CAP, isGameType } from "./config";
+import { akibaSkillGamesAbi, SETTLEMENT_TYPEHASH_PREIMAGE, START_INTENT_TYPEHASH_PREIMAGE } from "./contracts";
+import { seedCommitment, validateMemoryFlipReplay, validateRuleTapReplay } from "./replayValidation";
+import type { GameReplay, GameType, MemoryFlipReplay, RuleTapReplay, SettlementPayload } from "./types";
+
+const router = Router();
+const CELO_RPC = process.env.CELO_RPC_URL ?? "https://forno.celo.org";
+const CELO_CHAIN_ID = 42220n;
+const provider = new JsonRpcProvider(CELO_RPC);
+const skillGamesAddress = process.env.SKILL_GAMES_CONTRACT_ADDRESS ?? process.env.NEXT_PUBLIC_AKIBA_SKILL_GAMES_ADDRESS;
+const verifierPk = process.env.SKILL_GAMES_VERIFIER_PK;
+
+const BLOCKING_FLAGS = [
+  "impossible_completion_time",
+  "non_monotonic_action_log",
+  "input_during_pair_evaluation_lock",
+];
+
+function getSkillGames(readonly = false) {
+  if (!skillGamesAddress) throw new Error("SKILL_GAMES_CONTRACT_ADDRESS not set");
+  const runner = readonly || !verifierPk ? provider : new Wallet(verifierPk, provider);
+  return new Contract(skillGamesAddress, akibaSkillGamesAbi, runner);
+}
+
+function toMilesUnits(miles: number): bigint {
+  return BigInt(Math.round(miles)) * 10n ** 18n;
+}
+
+function toStableUnits(usd: number): bigint {
+  return BigInt(Math.round(usd * 1_000_000));
+}
+
+function buildSettlementDigest(params: {
+  sessionId: bigint;
+  player: string;
+  gameType: number;
+  score: bigint;
+  rewardMiles: bigint;
+  rewardStable: bigint;
+  expiry: bigint;
+  verifyingContract: string;
+}) {
+  return keccak256(
+    AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "uint256", "address", "uint8", "uint256", "uint256", "uint256", "uint256", "address", "uint256"],
+      [
+        id(SETTLEMENT_TYPEHASH_PREIMAGE),
+        params.sessionId,
+        params.player,
+        params.gameType,
+        params.score,
+        params.rewardMiles,
+        params.rewardStable,
+        params.expiry,
+        params.verifyingContract,
+        CELO_CHAIN_ID,
+      ]
+    )
+  );
+}
+
+function onchainDayStart(): string {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return new Date(Math.floor(nowSec / 86400) * 86400 * 1000).toISOString();
+}
+
+async function countSharedPlaysToday(walletAddress: string) {
+  const { count, error } = await supabase
+    .from("skill_game_sessions")
+    .select("*", { count: "exact", head: true })
+    .eq("wallet_address", walletAddress.toLowerCase())
+    .gte("created_at", onchainDayStart());
+  if (error) throw error;
+  return count ?? 0;
+}
+
+async function persistStartedSession(input: {
+  sessionId: string;
+  walletAddress: string;
+  gameType: GameType;
+  seedCommitment: string;
+}) {
+  const { error } = await supabase.from("skill_game_sessions").upsert({
+    session_id: input.sessionId,
+    wallet_address: input.walletAddress.toLowerCase(),
+    game_type: input.gameType,
+    seed_commitment: input.seedCommitment,
+    created_at: new Date().toISOString(),
+  });
+  if (error) throw error;
+}
+
+router.get("/status", async (req, res) => {
+  try {
+    const wallet = String(req.query.wallet ?? "");
+    const gameType = req.query.gameType;
+    if (!wallet || !isGameType(gameType)) {
+      res.status(400).json({ error: "wallet and gameType required" });
+      return;
+    }
+    const contract = getSkillGames(true);
+    const [status, nonce] = await Promise.all([
+      contract.playerStatus(wallet, GAME_TYPE_ID[gameType]),
+      contract.startNonces(wallet),
+    ]);
+    res.json({
+      credits: Number(status[0]),
+      playsToday: Number(status[1]),
+      playsRemaining: Math.min(Number(status[2]), SHARED_DAILY_PLAY_CAP),
+      nonce: Number(nonce),
+      contractAvailable: true,
+    });
+  } catch (err: any) {
+    console.error("[games/status]", err);
+    res.status(502).json({ error: err?.message ?? "contract-read-failed" });
+  }
+});
+
+router.post("/start-intent", async (req, res) => {
+  try {
+    if (!verifierPk || !skillGamesAddress) {
+      res.status(503).json({ error: "backend-not-configured" });
+      return;
+    }
+
+    const { gameType, walletAddress, seedCommitment: commitment, nonce, expiry, playerSignature } = req.body ?? {};
+    if (!isGameType(gameType) || !walletAddress || !commitment || nonce == null || !expiry || !playerSignature) {
+      res.status(400).json({ error: "missing-fields" });
+      return;
+    }
+    if (Date.now() / 1000 > Number(expiry)) {
+      res.status(400).json({ error: "intent-expired" });
+      return;
+    }
+    if ((await countSharedPlaysToday(walletAddress)) >= SHARED_DAILY_PLAY_CAP) {
+      res.status(429).json({ error: "shared-daily-cap-reached" });
+      return;
+    }
+
+    // Recover signer from the player's intent signature before spending gas.
+    try {
+      const INTENT_TYPEHASH = id(START_INTENT_TYPEHASH_PREIMAGE);
+      const CELO_CHAIN_ID_N = 42220n;
+      const digest = keccak256(
+        AbiCoder.defaultAbiCoder().encode(
+          ["bytes32", "address", "uint8", "bytes32", "uint256", "uint256", "address", "uint256"],
+          [INTENT_TYPEHASH, walletAddress, GAME_TYPE_ID[gameType], commitment, BigInt(nonce), BigInt(expiry), skillGamesAddress, CELO_CHAIN_ID_N]
+        )
+      );
+      const recovered = recoverAddress(hashMessage(getBytes(digest)), playerSignature);
+      if (recovered.toLowerCase() !== walletAddress.toLowerCase()) {
+        res.status(400).json({ error: "invalid-player-signature" });
+        return;
+      }
+    } catch {
+      res.status(400).json({ error: "invalid-player-signature" });
+      return;
+    }
+
+    const contract = getSkillGames(false);
+    const tx = await contract.startGameFor(
+      walletAddress,
+      GAME_TYPE_ID[gameType],
+      commitment,
+      BigInt(nonce),
+      BigInt(expiry),
+      playerSignature
+    );
+    const receipt = await tx.wait(1);
+    const iface = new Interface(akibaSkillGamesAbi);
+    let sessionId: string | null = null;
+    for (const log of receipt.logs ?? []) {
+      try {
+        const decoded = iface.parseLog(log);
+        if (decoded?.name === "GameStarted") {
+          sessionId = decoded.args.sessionId.toString();
+          break;
+        }
+      } catch {
+        // not our event
+      }
+    }
+    if (!sessionId) {
+      res.status(500).json({ error: "session-id-not-found-in-receipt" });
+      return;
+    }
+    await persistStartedSession({ sessionId, walletAddress, gameType, seedCommitment: commitment });
+    res.json({ sessionId, txHash: tx.hash });
+  } catch (err: any) {
+    console.error("[games/start-intent]", err);
+    res.status(500).json({ error: err?.shortMessage ?? err?.message ?? "contract-error" });
+  }
+});
+
+router.post("/verify", async (req, res) => {
+  try {
+    const { gameType, sessionId, walletAddress, replay, ownershipSig } = req.body as {
+      gameType?: GameType;
+      sessionId?: string;
+      walletAddress?: string;
+      replay?: GameReplay;
+      ownershipSig?: string;
+    };
+    if (!isGameType(gameType) || !sessionId || !walletAddress || !replay) {
+      res.status(400).json({ accepted: false, error: "missing-fields" });
+      return;
+    }
+
+    // Verify the caller owns walletAddress by recovering the signer of the sessionId.
+    if (skillGamesAddress) {
+      if (!ownershipSig) {
+        res.status(400).json({ accepted: false, error: "missing-ownership-sig" });
+        return;
+      }
+      try {
+        const recovered = recoverAddress(hashMessage(sessionId), ownershipSig);
+        if (recovered.toLowerCase() !== walletAddress.toLowerCase()) {
+          res.status(403).json({ accepted: false, error: "ownership-sig-mismatch" });
+          return;
+        }
+      } catch {
+        res.status(400).json({ accepted: false, error: "invalid-ownership-sig" });
+        return;
+      }
+    }
+
+    if ((await countSharedPlaysToday(walletAddress)) > SHARED_DAILY_PLAY_CAP) {
+      res.json({
+        accepted: false,
+        antiAbuseFlags: ["daily_cap_exceeded"],
+        result: { sessionId, gameType, score: 0, mistakes: 0, completed: false, elapsedMs: 0, rewardMiles: 0, rewardStable: 0 },
+        settled: false,
+      });
+      return;
+    }
+
+    const replaySeed = (replay as any).seed as string | undefined;
+    if (!replaySeed) {
+      res.status(400).json({ accepted: false, error: "missing-seed" });
+      return;
+    }
+    const { data: sessionRow } = await supabase
+      .from("skill_game_sessions")
+      .select("seed_commitment, accepted")
+      .eq("session_id", sessionId)
+      .maybeSingle();
+
+    if (sessionRow?.accepted === true) {
+      res.status(409).json({ accepted: false, error: "session-already-settled" });
+      return;
+    }
+
+    const expectedCommitment = sessionRow?.seed_commitment as string | undefined;
+    if (expectedCommitment) {
+      const actualCommitment = seedCommitment(replaySeed, walletAddress, gameType);
+      if (actualCommitment.toLowerCase() !== expectedCommitment.toLowerCase()) {
+        res.status(400).json({ accepted: false, error: "seed-commitment-mismatch" });
+        return;
+      }
+    }
+
+    const validation =
+      gameType === "rule_tap"
+        ? validateRuleTapReplay(replay as RuleTapReplay)
+        : validateMemoryFlipReplay(replay as MemoryFlipReplay);
+    const accepted = !validation.flags.some((flag) => BLOCKING_FLAGS.includes(flag));
+
+    const { error: updateError } = await supabase.from("skill_game_sessions").upsert({
+      session_id: sessionId,
+      wallet_address: walletAddress.toLowerCase(),
+      game_type: gameType,
+      score: validation.result.score,
+      reward_miles: accepted ? validation.result.rewardMiles : 0,
+      reward_stable: accepted ? validation.result.rewardStable : 0,
+      accepted,
+      anti_abuse_flags: validation.flags,
+    });
+    if (updateError) throw updateError;
+
+    if (!accepted) {
+      res.json({
+        accepted: false,
+        antiAbuseFlags: validation.flags,
+        result: { ...validation.result, rewardMiles: 0, rewardStable: 0 },
+        settled: false,
+      });
+      return;
+    }
+    if (!verifierPk || !skillGamesAddress) {
+      res.json({ accepted: true, antiAbuseFlags: validation.flags, result: validation.result, settlement: null, settled: false });
+      return;
+    }
+
+    const expiry = BigInt(Math.floor(Date.now() / 1000) + 15 * 60);
+    const rewardMiles = toMilesUnits(validation.result.rewardMiles);
+    const rewardStable = toStableUnits(validation.result.rewardStable);
+    const score = BigInt(validation.result.score);
+    const numericSessionId = BigInt(sessionId);
+    const chainGameType = GAME_TYPE_ID[gameType];
+    const digest = buildSettlementDigest({
+      sessionId: numericSessionId,
+      player: walletAddress,
+      gameType: chainGameType,
+      score,
+      rewardMiles,
+      rewardStable,
+      expiry,
+      verifyingContract: skillGamesAddress,
+    });
+    const wallet = new Wallet(verifierPk, provider);
+    const signature = await wallet.signMessage(getBytes(digest));
+    const settlement: SettlementPayload = {
+      sessionId,
+      player: walletAddress,
+      gameType,
+      score: validation.result.score,
+      rewardMiles: validation.result.rewardMiles,
+      rewardStable: validation.result.rewardStable,
+      expiry: Number(expiry),
+      signature,
+      digest,
+    };
+
+    // Persist the signed payload so the retry job can resubmit without re-signing.
+    await supabase.from("skill_game_sessions").update({
+      settlement_sig:    signature,
+      settlement_expiry: Number(expiry),
+    }).eq("session_id", sessionId);
+
+    void attemptSettle(sessionId, numericSessionId, score, rewardMiles, rewardStable, expiry, signature);
+
+    res.json({ accepted: true, antiAbuseFlags: validation.flags, result: validation.result, settlement, settled: false });
+  } catch (err: any) {
+    console.error("[games/verify]", err);
+    res.status(500).json({ accepted: false, error: err?.message ?? "server-error" });
+  }
+});
+
+async function attemptSettle(
+  sessionId: string,
+  numericSessionId: bigint,
+  score: bigint,
+  rewardMiles: bigint,
+  rewardStable: bigint,
+  expiry: bigint,
+  signature: string
+): Promise<boolean> {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const contract = getSkillGames(false);
+      const tx = await contract.settleGame(numericSessionId, score, rewardMiles, rewardStable, expiry, signature);
+      await tx.wait(1);
+      await supabase.from("skill_game_sessions").update({
+        settle_tx_hash: tx.hash,
+        settled_at: new Date().toISOString(),
+      }).eq("session_id", sessionId);
+      return true;
+    } catch (err: any) {
+      const msg = err?.shortMessage ?? err?.message ?? String(err);
+      console.error(`[games/settle] attempt ${attempt}/${MAX_ATTEMPTS} for session ${sessionId} failed:`, msg);
+      await supabase.from("skill_game_sessions")
+        .update({ settle_attempts: attempt })
+        .eq("session_id", sessionId);
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, 2000 * attempt));
+      }
+    }
+  }
+  return false;
+}
+
+// Retry accepted sessions that were never settled on-chain (e.g. process restart mid-flight).
+// Runs every 10 minutes. Only retries sessions whose signature hasn't expired yet.
+const RETRY_INTERVAL_MS = 10 * 60 * 1000;
+const MAX_SETTLE_ATTEMPTS = 5;
+
+async function retryPendingSettlements() {
+  if (!verifierPk || !skillGamesAddress) return;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const { data, error } = await supabase
+    .from("skill_game_sessions")
+    .select("session_id, score, reward_miles, reward_stable, settlement_sig, settlement_expiry, settle_attempts")
+    .eq("accepted", true)
+    .is("settled_at", null)
+    .not("settlement_sig", "is", null)
+    .gt("settlement_expiry", nowSec)
+    .lt("settle_attempts", MAX_SETTLE_ATTEMPTS)
+    .order("created_at", { ascending: true })
+    .limit(20);
+
+  if (error) { console.error("[games/settle-retry] query failed", error); return; }
+  if (!data?.length) return;
+
+  console.log(`[games/settle-retry] retrying ${data.length} unsettled sessions`);
+  for (const row of data) {
+    await attemptSettle(
+      row.session_id,
+      BigInt(row.session_id),
+      BigInt(row.score),
+      toMilesUnits(row.reward_miles),
+      toStableUnits(row.reward_stable),
+      BigInt(row.settlement_expiry),
+      row.settlement_sig
+    );
+  }
+}
+
+setInterval(() => { void retryPendingSettlements(); }, RETRY_INTERVAL_MS);
+
+export default router;

--- a/packages/backend/src/games/score.ts
+++ b/packages/backend/src/games/score.ts
@@ -1,0 +1,29 @@
+import { GAME_CONFIGS } from "./config";
+import type { GameType } from "./types";
+
+export function rewardForScore(gameType: GameType, score: number) {
+  const thresholds = [...GAME_CONFIGS[gameType].thresholds].sort((a, b) => b.minScore - a.minScore);
+  const achieved = thresholds.find((threshold) => score >= threshold.minScore);
+  return {
+    rewardMiles: achieved?.miles ?? 0,
+    rewardStable: achieved?.stable ?? 0,
+  };
+}
+
+export function scoreRuleTap(correct: number, mistakes: number) {
+  return Math.max(0, correct - mistakes * 2);
+}
+
+export function scoreMemoryFlip(params: {
+  completed: boolean;
+  matches: number;
+  moves: number;
+  mistakes: number;
+  elapsedMs: number;
+  durationMs: number;
+}) {
+  const completion = params.completed ? 500 : params.matches * 45;
+  const timeBonus = params.completed ? Math.max(0, Math.round((params.durationMs - params.elapsedMs) / 100)) : 0;
+  const efficiencyBonus = Math.max(0, 240 - params.moves * 10);
+  return Math.max(0, completion + timeBonus + efficiencyBonus - params.mistakes * 15);
+}

--- a/packages/backend/src/games/types.ts
+++ b/packages/backend/src/games/types.ts
@@ -1,0 +1,65 @@
+export type GameType = "rule_tap" | "memory_flip";
+
+export type RewardThreshold = {
+  label: string;
+  minScore: number;
+  miles: number;
+  stable: number;
+  note?: string;
+};
+
+export type GameResult = {
+  sessionId: string;
+  gameType: GameType;
+  score: number;
+  mistakes: number;
+  moves?: number;
+  matches?: number;
+  completed: boolean;
+  elapsedMs: number;
+  rewardMiles: number;
+  rewardStable: number;
+  reason?: string;
+};
+
+export type RuleTapAction = {
+  type: "tap";
+  offsetMs: number;
+  tileIndex: number;
+};
+
+export type RuleTapReplay = {
+  sessionId: string;
+  seed: string;
+  startedAt: string;
+  durationMs: number;
+  actions: RuleTapAction[];
+};
+
+export type MemoryFlipAction = {
+  type: "flip";
+  offsetMs: number;
+  cardIndex: number;
+};
+
+export type MemoryFlipReplay = {
+  sessionId: string;
+  seed: string;
+  startedAt: string;
+  durationMs: number;
+  actions: MemoryFlipAction[];
+};
+
+export type GameReplay = RuleTapReplay | MemoryFlipReplay;
+
+export type SettlementPayload = {
+  sessionId: string;
+  player: string;
+  gameType: GameType;
+  score: number;
+  rewardMiles: number;
+  rewardStable: number;
+  expiry: number;
+  signature: string;
+  digest?: string;
+};

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,13 +2,13 @@
 import express from "express";
 import * as dotenv from "dotenv";
 import questRouter from "./questRoutes";
+import gamesRouter from "./games/routes";
 import { startMintWorker, runDrain, releaseCurrentLock } from "./mintWorker";
 import { startBurnBlacklistWatcher } from "./burnBlacklistWatcher";
 import { startProsperityPassWorker, releaseCurrentPassLock } from "./prosperityPassWorker";
 import { startDiceSweeper, runDiceSweep } from "./diceSweeper";
 import { startVaultEventWatcher } from "./vaultEventWatcher";
 import { startVaultRewardScheduler } from "./vaultRewardScheduler";
-import { startAutoDailyCheckinScheduler, runAutoDailyCheckins } from "./autoDailyCheckinScheduler";
 
 dotenv.config();
 
@@ -17,6 +17,7 @@ app.use(express.json());
 
 // Mount the quest routes at /claim
 app.use("/claim", questRouter);
+app.use("/games", gamesRouter);
 
 app.get("/", (req, res) => {
   res.send("Welcome to the Minimiles Daily Quests Backend!");
@@ -50,25 +51,6 @@ app.post("/drain", async (req, res) => {
   res.json({ ok: true, message: "drain triggered" });
 });
 
-// Manual auto daily check-in run (protected)
-app.post("/auto-daily-checkins/run", async (req, res) => {
-  const secret = process.env.ADMIN_QUEUE_SECRET ?? "";
-  const auth = req.headers.authorization;
-  if (!secret || auth !== `Bearer ${secret}`) {
-    res.status(401).json({ error: "unauthorized" });
-    return;
-  }
-
-  const runDate = typeof req.body?.runDate === "string" ? req.body.runDate : undefined;
-
-  try {
-    const result = await runAutoDailyCheckins(runDate);
-    res.json({ ok: true, ...result });
-  } catch (err: any) {
-    res.status(500).json({ ok: false, error: err?.message ?? "auto daily check-in failed" });
-  }
-});
-
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
@@ -78,7 +60,6 @@ app.listen(PORT, () => {
   startDiceSweeper();
   startVaultEventWatcher();
   startVaultRewardScheduler();
-  startAutoDailyCheckinScheduler();
 });
 
 // Release the mint queue lock before Railway (or any host) kills the process.

--- a/packages/backend/src/mintWorker.ts
+++ b/packages/backend/src/mintWorker.ts
@@ -21,9 +21,10 @@ const BATCH_RETRY_ATTEMPTS = 3;
 const BATCH_RETRY_DELAY_MS = 5_000;
 const RECEIPT_POLL_MS = 5_000;
 const STALLED_JOB_AGE_MS = LOCK_LEASE_SECONDS * 1000 * 2;
-const FORCE_SINGLE_TX_MINTS =
-  (process.env.MINT_WORKER_SINGLE_TX ?? "").trim().toLowerCase() === "true" ||
-  (process.env.MINT_WORKER_SINGLE_TX ?? "").trim() === "1";
+const SUPABASE_TIMEOUT_MS = Number(process.env.MINT_WORKER_SUPABASE_TIMEOUT_MS ?? "20000");
+const RUN_WATCHDOG_MS = Number(
+  process.env.MINT_WORKER_RUN_WATCHDOG_MS ?? String(LOCK_LEASE_SECONDS * 1000 * 2)
+);
 
 // Round-robin across these RPCs so wallets don't all hammer the same node.
 const RPC_URLS = [
@@ -32,7 +33,6 @@ const RPC_URLS = [
 ];
 
 const BATCH_MINT_ABI = [
-  "function mint(address account, uint256 amount) external",
   "function batchMint(address[] calldata accounts, uint256[] calldata amounts) external",
   "function claimV2TokensFor(address user) external",
   "error Blacklisted()",
@@ -123,10 +123,6 @@ function describeFailure(err: any): string {
   return `${kind}: ${msg}`;
 }
 
-function shouldMintWithSingleTx(job: any): boolean {
-  return FORCE_SINGLE_TX_MINTS || job.payload?.autoClaim === true;
-}
-
 function isTransientError(err: any): boolean {
   const msg: string = (err?.shortMessage ?? err?.message ?? "").toLowerCase();
   return (
@@ -134,6 +130,7 @@ function isTransientError(err: any): boolean {
     msg.includes("service unavailable") ||
     msg.includes("could not coalesce") ||
     msg.includes("timeout") ||
+    msg.includes("timed out") ||
     msg.includes("network error") ||
     msg.includes("econnreset") ||
     msg.includes("econnrefused") ||
@@ -146,6 +143,24 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function formatMs(ms: number) {
+  if (ms < 1000) return `${ms}ms`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+async function withTimeout<T>(operation: PromiseLike<T>, ms: number, label: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+
+  try {
+    return await Promise.race([Promise.resolve(operation), timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 async function waitForReceiptWithFallback(txHash: string, label: string) {
   const deadline = Date.now() + TX_TIMEOUT_MS;
   let lastErr: any = null;
@@ -154,7 +169,11 @@ async function waitForReceiptWithFallback(txHash: string, label: string) {
     for (const url of RPC_URLS) {
       try {
         const provider = new ethers.JsonRpcProvider(url);
-        const receipt = await provider.getTransactionReceipt(txHash);
+        const receipt = await withTimeout(
+          provider.getTransactionReceipt(txHash),
+          RECEIPT_POLL_MS,
+          `${label} receipt poll ${url}`
+        );
         if (receipt) return receipt;
       } catch (err: any) {
         lastErr = err;
@@ -172,45 +191,95 @@ async function waitForReceiptWithFallback(txHash: string, label: string) {
 }
 
 async function permanentlyFail(jobId: string, reason: string) {
-  await supabase.rpc("fail_minipoint_mint_job", { p_job_id: jobId, p_error: reason });
+  await withTimeout(
+    supabase.rpc("fail_minipoint_mint_job", { p_job_id: jobId, p_error: reason }),
+    SUPABASE_TIMEOUT_MS,
+    `fail job ${jobId}`
+  );
 }
 
 async function renewLock(owner: string) {
-  await supabase.rpc("acquire_minipoint_mint_queue_lock", {
-    p_lock_name: LOCK_NAME,
-    p_owner: owner,
-    p_lease_seconds: LOCK_LEASE_SECONDS,
-  });
+  const { data, error } = await withTimeout(
+    supabase.rpc("acquire_minipoint_mint_queue_lock", {
+      p_lock_name: LOCK_NAME,
+      p_owner: owner,
+      p_lease_seconds: LOCK_LEASE_SECONDS,
+    }),
+    SUPABASE_TIMEOUT_MS,
+    "renew mint queue lock"
+  );
+  if (error) throw error;
+  if (!data) throw new Error(`Lost mint queue lock for owner ${owner}`);
+}
+
+async function assertActiveLock(owner: string) {
+  const { data, error } = await withTimeout(
+    supabase
+      .from("minipoint_mint_queue_locks")
+      .select("owner, locked_until")
+      .eq("lock_name", LOCK_NAME)
+      .maybeSingle(),
+    SUPABASE_TIMEOUT_MS,
+    "check mint queue lock"
+  );
+  if (error) throw error;
+
+  const lockedUntil = data?.locked_until ? new Date(data.locked_until).getTime() : 0;
+  if (!data || data.owner !== owner || lockedUntil <= Date.now()) {
+    throw new Error(`Mint queue lock is no longer owned by ${owner}`);
+  }
 }
 
 async function resetStalledJobs() {
   const cutoff = new Date(Date.now() - STALLED_JOB_AGE_MS).toISOString();
-  const { data } = await supabase
-    .from("minipoint_mint_jobs")
-    .update({ status: "pending" })
-    .eq("status", "processing")
-    .lt("updated_at", cutoff)
-    .select("id");
+  const { data, error } = await withTimeout(
+    supabase
+      .from("minipoint_mint_jobs")
+      .update({ status: "pending", processing_by: null, processing_started_at: null })
+      .eq("status", "processing")
+      .lt("updated_at", cutoff)
+      .select("id"),
+    SUPABASE_TIMEOUT_MS,
+    "reset stalled mint jobs"
+  );
+  if (error) throw error;
   const count = data?.length ?? 0;
   if (count > 0) console.log(`[mintWorker] Unstuck ${count} stalled jobs`);
 }
 
 // Single bulk fetch + mark-processing instead of N sequential RPC calls.
-async function claimBatch(count: number): Promise<any[]> {
-  const { data: jobs, error } = await supabase
-    .from("minipoint_mint_jobs")
-    .select("*")
-    .eq("status", "pending")
-    .order("created_at", { ascending: true })
-    .limit(count);
+async function claimBatch(count: number, owner: string): Promise<any[]> {
+  const nowIso = new Date().toISOString();
+  const { data: jobs, error } = await withTimeout(
+    supabase
+      .from("minipoint_mint_jobs")
+      .select("*")
+      .eq("status", "pending")
+      .lte("available_at", nowIso)
+      .order("created_at", { ascending: true })
+      .limit(count),
+    SUPABASE_TIMEOUT_MS,
+    "claim mint jobs select"
+  );
 
   if (error) throw error;
   if (!jobs || jobs.length === 0) return [];
 
-  await supabase
-    .from("minipoint_mint_jobs")
-    .update({ status: "processing", updated_at: new Date().toISOString() })
-    .in("id", jobs.map((j) => j.id));
+  const { error: updateError } = await withTimeout(
+    supabase
+      .from("minipoint_mint_jobs")
+      .update({
+        status: "processing",
+        processing_by: owner,
+        processing_started_at: nowIso,
+        updated_at: nowIso,
+      })
+      .eq("status", "pending")
+      .in("id", jobs.map((j) => j.id)),
+    SUPABASE_TIMEOUT_MS,
+    "claim mint jobs mark-processing"
+  );
+  if (updateError) throw updateError;
 
   return jobs;
 }
@@ -242,32 +311,49 @@ async function applyBatchPayloads(jobs: any[], txHash: string) {
     .filter((j) => j.payload?.kind === "profile_milestone" && j.payload.milestone !== 50)
     .map((j) => j.payload.userAddress.toLowerCase());
 
-  // poll_completion: reconcile reward_queued status back onto the response row
-  const pollJobs = jobs.filter((j) => j.payload?.kind === "poll_completion");
-
   if (dailyRows.length > 0) {
-    const { error } = await supabase
-      .from("daily_engagements")
-      .upsert(dailyRows, { onConflict: "user_address,quest_id,claimed_at", ignoreDuplicates: true });
+    const { error } = await withTimeout(
+      supabase
+        .from("daily_engagements")
+        .upsert(dailyRows, { onConflict: "user_address,quest_id,claimed_at", ignoreDuplicates: true }),
+      SUPABASE_TIMEOUT_MS,
+      "bulk daily_engagements"
+    );
     if (error && error.code !== "23505") console.error("[mintWorker] bulk daily_engagements:", error.message);
   }
 
   if (partnerRows.length > 0) {
-    const { error } = await supabase
-      .from("partner_engagements")
-      .upsert(partnerRows, { onConflict: "user_address,partner_quest_id", ignoreDuplicates: true });
+    const { error } = await withTimeout(
+      supabase
+        .from("partner_engagements")
+        .upsert(partnerRows, { onConflict: "user_address,partner_quest_id", ignoreDuplicates: true }),
+      SUPABASE_TIMEOUT_MS,
+      "bulk partner_engagements"
+    );
     if (error && error.code !== "23505") console.error("[mintWorker] bulk partner_engagements:", error.message);
   }
 
   if (m50.length > 0) {
-    const { error } = await supabase
-      .from("users").update({ profile_milestone_50_claimed: true }).in("user_address", m50);
+    const { error } = await withTimeout(
+      supabase
+        .from("users")
+        .update({ profile_milestone_50_claimed: true })
+        .in("user_address", m50),
+      SUPABASE_TIMEOUT_MS,
+      "bulk milestone_50"
+    );
     if (error) console.error("[mintWorker] bulk milestone_50:", error.message);
   }
 
   if (m100.length > 0) {
-    const { error } = await supabase
-      .from("users").update({ profile_milestone_100_claimed: true }).in("user_address", m100);
+    const { error } = await withTimeout(
+      supabase
+        .from("users")
+        .update({ profile_milestone_100_claimed: true })
+        .in("user_address", m100),
+      SUPABASE_TIMEOUT_MS,
+      "bulk milestone_100"
+    );
     if (error) console.error("[mintWorker] bulk milestone_100:", error.message);
   }
 
@@ -275,23 +361,27 @@ async function applyBatchPayloads(jobs: any[], txHash: string) {
   // The vault_reward_snapshots row is already marked complete by the scheduler
   // before jobs are enqueued. Nothing to do here beyond completing the job row.
 
-  // For each confirmed poll_completion job, mark the matching poll_responses
-  // row as reward_queued=true (it was already set at submit time, but if the
-  // enqueue failed there and a retry succeeded here, this closes the gap).
-  for (const job of pollJobs) {
-    const { error } = await supabase
-      .from("poll_responses")
-      .update({ reward_queued: true })
-      .eq("poll_id", job.payload.pollId)
-      .eq("wallet_address", job.payload.userAddress);
-    if (error) console.error(`[mintWorker] poll_completion reconcile ${job.id}:`, error.message);
-  }
+  // poll_completion — no extra side-effects: poll_responses.reward_queued is
+  // set at submit time (or by the watcher on retry). Nothing to do here.
 
-  const { error: completeErr } = await supabase
-    .from("minipoint_mint_jobs")
-    .update({ status: "completed", tx_hash: txHash, updated_at: new Date().toISOString() })
-    .in("id", jobs.map((j) => j.id));
-  if (completeErr) console.error("[mintWorker] bulk complete:", completeErr.message);
+  const { error: completeErr } = await withTimeout(
+    supabase
+      .from("minipoint_mint_jobs")
+      .update({
+        status: "completed",
+        tx_hash: txHash,
+        processing_by: null,
+        processing_started_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .in("id", jobs.map((j) => j.id)),
+    SUPABASE_TIMEOUT_MS,
+    "bulk complete mint jobs"
+  );
+  if (completeErr) {
+    console.error("[mintWorker] bulk complete:", completeErr.message);
+    throw completeErr;
+  }
 }
 
 // ── Mint helpers ──────────────────────────────────────────────────────────────
@@ -336,7 +426,10 @@ async function processMintJobsIndividually(
 
   for (const job of jobs) {
     try {
-      const tx = await contract.mint(job.user_address, ethers.parseUnits(String(job.points), 18));
+      const tx = await contract.batchMint(
+        [job.user_address],
+        [ethers.parseUnits(String(job.points), 18)]
+      );
       const receipt = await waitForReceiptWithFallback(tx.hash, `${label} single ${job.id}`);
       succeeded.push({ ...job, txHash: receipt.hash ?? tx.hash });
     } catch (err: any) {
@@ -369,9 +462,13 @@ async function handleFailedJobs(failed: { job: any; msg: string; err: any }[]) {
       await permanentlyFail(job.id, msg);
     } else {
       const delay = Math.min(30, 2 ** Math.max(1, job.attempts ?? 1));
-      await supabase.rpc("retry_minipoint_mint_job", {
-        p_job_id: job.id, p_error: msg, p_delay_seconds: delay,
-      });
+      await withTimeout(
+        supabase.rpc("retry_minipoint_mint_job", {
+          p_job_id: job.id, p_error: msg, p_delay_seconds: delay,
+        }),
+        SUPABASE_TIMEOUT_MS,
+        `retry job ${job.id}`
+      );
     }
   }
 
@@ -389,27 +486,57 @@ const WALLETS = makeWallets();
 // ── Lock state (exported for graceful shutdown) ───────────────────────────────
 let currentLockOwner: string | null = null;
 
+type DrainRunState = {
+  owner: string;
+  startedAt: number;
+  lastProgressAt: number;
+  phase: string;
+};
+
+let activeRun: DrainRunState | null = null;
+
+function setRunPhase(owner: string, phase: string) {
+  if (activeRun?.owner !== owner) return;
+  activeRun.phase = phase;
+  activeRun.lastProgressAt = Date.now();
+}
+
+function describeRun(run: DrainRunState) {
+  const now = Date.now();
+  return `owner=${run.owner} phase=${run.phase} age=${formatMs(now - run.startedAt)} idle=${formatMs(now - run.lastProgressAt)}`;
+}
+
 export async function releaseCurrentLock() {
   if (!currentLockOwner) return;
+  const owner = currentLockOwner;
   try {
-    await supabase.rpc("release_minipoint_mint_queue_lock", {
-      p_lock_name: LOCK_NAME,
-      p_owner: currentLockOwner,
-    });
+    await withTimeout(
+      supabase.rpc("release_minipoint_mint_queue_lock", {
+        p_lock_name: LOCK_NAME,
+        p_owner: owner,
+      }),
+      SUPABASE_TIMEOUT_MS,
+      "release mint queue lock on shutdown"
+    );
     console.log("[mintWorker] Lock released on shutdown");
   } catch (e) {
     // best-effort
   }
-  currentLockOwner = null;
+  if (currentLockOwner === owner) currentLockOwner = null;
+  if (activeRun?.owner === owner) activeRun = null;
 }
 
 // On startup, any held lock belongs to a dead process — clear it directly.
 async function clearStaleLockOnStartup() {
   try {
-    await supabase
-      .from("minipoint_mint_queue_locks")
-      .update({ locked_until: new Date().toISOString() })
-      .eq("lock_name", LOCK_NAME);
+    await withTimeout(
+      supabase
+        .from("minipoint_mint_queue_locks")
+        .update({ locked_until: new Date().toISOString() })
+        .eq("lock_name", LOCK_NAME),
+      SUPABASE_TIMEOUT_MS,
+      "clear stale mint queue lock on startup"
+    );
     console.log("[mintWorker] Cleared stale lock on startup");
   } catch {
     // Table name may differ — silently ignore, lock will expire on its own
@@ -417,24 +544,44 @@ async function clearStaleLockOnStartup() {
 }
 
 // ── Main drain run ────────────────────────────────────────────────────────────
-let isRunning = false;
-
 export async function runDrain() {
-  if (isRunning) {
-    console.log("[mintWorker] Already running, skipping");
-    return;
+  if (activeRun) {
+    const idleMs = Date.now() - activeRun.lastProgressAt;
+    if (idleMs <= RUN_WATCHDOG_MS) {
+      console.log(`[mintWorker] Already running, skipping (${describeRun(activeRun)})`);
+      return;
+    }
+
+    console.warn(
+      `[mintWorker] Watchdog clearing stale in-process run (${describeRun(activeRun)}, watchdog=${formatMs(RUN_WATCHDOG_MS)})`
+    );
+    if (currentLockOwner === activeRun.owner) currentLockOwner = null;
+    activeRun = null;
   }
-  isRunning = true;
+
+  const wallets = WALLETS;
+  const owner = randomUUID();
+  activeRun = {
+    owner,
+    startedAt: Date.now(),
+    lastProgressAt: Date.now(),
+    phase: "starting",
+  };
 
   try {
-    const wallets = WALLETS;
-    const owner = randomUUID();
+    console.log(`[mintWorker] Drain start owner=${owner}`);
 
-    const { data: acquired } = await supabase.rpc("acquire_minipoint_mint_queue_lock", {
-      p_lock_name: LOCK_NAME,
-      p_owner: owner,
-      p_lease_seconds: LOCK_LEASE_SECONDS,
-    });
+    setRunPhase(owner, "acquire-lock");
+    const { data: acquired, error: acquireError } = await withTimeout(
+      supabase.rpc("acquire_minipoint_mint_queue_lock", {
+        p_lock_name: LOCK_NAME,
+        p_owner: owner,
+        p_lease_seconds: LOCK_LEASE_SECONDS,
+      }),
+      SUPABASE_TIMEOUT_MS,
+      "acquire mint queue lock"
+    );
+    if (acquireError) throw acquireError;
 
     if (!acquired) {
       console.log("[mintWorker] Lock busy, skipping this run");
@@ -448,13 +595,16 @@ export async function runDrain() {
     let round = 0;
 
     try {
+      setRunPhase(owner, "reset-stalled");
       await resetStalledJobs();
 
       while (true) {
+        setRunPhase(owner, "renew-lock");
         await renewLock(owner);
 
         // Claim enough jobs for all wallets in one shot
-        const allJobs = await claimBatch(BATCH_SIZE * wallets.length);
+        setRunPhase(owner, "claim-batch");
+        const allJobs = await claimBatch(BATCH_SIZE * wallets.length, owner);
         if (allJobs.length === 0) {
           console.log("[mintWorker] Queue empty, done.");
           break;
@@ -464,32 +614,30 @@ export async function runDrain() {
         const migrationJobs = allJobs.filter((j) => j.payload?.kind === "v2_migration");
 
         round++;
-        const singleTxMintJobs = mintJobs.filter(shouldMintWithSingleTx);
-        const batchMintJobs = mintJobs.filter((j) => !shouldMintWithSingleTx(j));
-
-        console.log(
-          `[mintWorker] Round ${round}: ${mintJobs.length} mint (${batchMintJobs.length} batch, ${singleTxMintJobs.length} single-tx) across ${wallets.length} wallet(s), ${migrationJobs.length} migration`
-        );
+        console.log(`[mintWorker] Round ${round}: ${mintJobs.length} mint across ${wallets.length} wallet(s), ${migrationJobs.length} migration`);
 
         // ── Split mint jobs across wallets and fire in parallel ─────────────
-        if (batchMintJobs.length > 0) {
-          const chunkSize = Math.ceil(batchMintJobs.length / wallets.length);
+        if (mintJobs.length > 0) {
+          setRunPhase(owner, `round-${round}-mint`);
+          await assertActiveLock(owner);
+
+          const chunkSize = Math.ceil(mintJobs.length / wallets.length);
           const chunks = wallets
             .map((w, i) => ({
               ...w,
               label: `W${i + 1}`,
-              jobs: batchMintJobs.slice(i * chunkSize, (i + 1) * chunkSize),
+              jobs: mintJobs.slice(i * chunkSize, (i + 1) * chunkSize),
             }))
             .filter((c) => c.jobs.length > 0);
 
           const results = await Promise.allSettled(
             chunks.map(async ({ contract, jobs, label }) => {
+              let txHash: string | null = null;
               try {
-                const txHash = await processMintBatch(jobs, contract, label);
-                await applyBatchPayloads(jobs, txHash);
-                return { minted: jobs.length };
+                txHash = await processMintBatch(jobs, contract, label);
               } catch (batchErr: any) {
                 console.warn(`[mintWorker] ${label} batch failed, falling back: ${batchErr?.shortMessage ?? batchErr?.message}`);
+                setRunPhase(owner, `round-${round}-fallback-${label}`);
                 const { succeeded, failed } = await processMintJobsIndividually(jobs, contract, label);
 
                 const byHash = new Map<string, any[]>();
@@ -499,61 +647,39 @@ export async function runDrain() {
                   byHash.set(j.txHash, arr);
                 }
                 for (const [hash, group] of byHash) {
+                  setRunPhase(owner, `round-${round}-fallback-complete-${label}`);
                   await applyBatchPayloads(group, hash);
                 }
                 await handleFailedJobs(failed);
                 return { minted: succeeded.length };
               }
+
+              setRunPhase(owner, `round-${round}-complete-${label}`);
+              await applyBatchPayloads(jobs, txHash);
+              return { minted: jobs.length };
             })
           );
 
           for (const result of results) {
             if (result.status === "fulfilled") totalMinted += result.value.minted;
-          }
-        }
-
-        // ── Auto-claim experiment jobs — one direct mint tx per wallet ──────
-        if (singleTxMintJobs.length > 0) {
-          const chunkSize = Math.ceil(singleTxMintJobs.length / wallets.length);
-          const chunks = wallets
-            .map((w, i) => ({
-              ...w,
-              label: `W${i + 1} single`,
-              jobs: singleTxMintJobs.slice(i * chunkSize, (i + 1) * chunkSize),
-            }))
-            .filter((c) => c.jobs.length > 0);
-
-          const results = await Promise.allSettled(
-            chunks.map(async ({ contract, jobs, label }) => {
-              const { succeeded, failed } = await processMintJobsIndividually(jobs, contract, label);
-
-              const byHash = new Map<string, any[]>();
-              for (const j of succeeded) {
-                const arr = byHash.get(j.txHash) ?? [];
-                arr.push(j);
-                byHash.set(j.txHash, arr);
-              }
-              for (const [hash, group] of byHash) {
-                await applyBatchPayloads(group, hash);
-              }
-              await handleFailedJobs(failed);
-              return { minted: succeeded.length };
-            })
-          );
-
-          for (const result of results) {
-            if (result.status === "fulfilled") totalMinted += result.value.minted;
+            else throw result.reason;
           }
         }
 
         // ── Migration jobs — serial, each reads V1 balance on-chain ─────────
         for (const job of migrationJobs) {
           try {
+            setRunPhase(owner, `migration-${job.id}`);
+            await assertActiveLock(owner);
             const tx = await wallets[0].contract.claimV2TokensFor(job.user_address);
             const receipt = await waitForReceiptWithFallback(tx.hash, `migration ${job.id}`);
             const txHash: string = receipt.hash ?? tx.hash;
             console.log(`[mintWorker] ✓ Migrated ${job.user_address} tx: ${txHash}`);
-            await supabase.rpc("complete_minipoint_mint_job", { p_job_id: job.id, p_tx_hash: txHash });
+            await withTimeout(
+              supabase.rpc("complete_minipoint_mint_job", { p_job_id: job.id, p_tx_hash: txHash }),
+              SUPABASE_TIMEOUT_MS,
+              `complete migration job ${job.id}`
+            );
             totalMigrated++;
           } catch (err: any) {
             const msg = err?.shortMessage ?? err?.message ?? "error";
@@ -564,7 +690,11 @@ export async function runDrain() {
               await permanentlyFail(job.id, msg);
             } else {
               const delay = Math.min(30, 2 ** Math.max(1, job.attempts ?? 1));
-              await supabase.rpc("retry_minipoint_mint_job", { p_job_id: job.id, p_error: msg, p_delay_seconds: delay });
+              await withTimeout(
+                supabase.rpc("retry_minipoint_mint_job", { p_job_id: job.id, p_error: msg, p_delay_seconds: delay }),
+                SUPABASE_TIMEOUT_MS,
+                `retry migration job ${job.id}`
+              );
             }
           }
         }
@@ -572,15 +702,20 @@ export async function runDrain() {
         console.log(`[mintWorker] Round ${round} done — ${totalMinted} minted, ${totalMigrated} migrated so far`);
       }
     } finally {
-      await supabase.rpc("release_minipoint_mint_queue_lock", { p_lock_name: LOCK_NAME, p_owner: owner });
-      currentLockOwner = null;
+      setRunPhase(owner, "release-lock");
+      await withTimeout(
+        supabase.rpc("release_minipoint_mint_queue_lock", { p_lock_name: LOCK_NAME, p_owner: owner }),
+        SUPABASE_TIMEOUT_MS,
+        "release mint queue lock"
+      );
+      if (currentLockOwner === owner) currentLockOwner = null;
     }
 
     console.log(`[mintWorker] Complete — ${totalMinted} minted, ${totalMigrated} migrated`);
   } catch (err: any) {
     console.error("[mintWorker] Fatal error:", err?.message);
   } finally {
-    isRunning = false;
+    if (activeRun?.owner === owner) activeRun = null;
   }
 }
 


### PR DESCRIPTION
…ardening

- Add /games routes: start-intent, verify, status, leaderboard
- Ownership signature check on verify to prevent replay spoofing
- Sig pre-validation on start-intent before chain submission
- keccak256-based seed commitment (replaces weak FNV-32)
- Session double-submit guard (409 on already-accepted sessions)
- Settlement retry worker: persists signed payload, retries on-chain up to 5x with backoff
- On-chain day boundary alignment for daily cap (floor(timestamp/86400))
- Per-request Supabase client